### PR TITLE
license: add 2024 copyrights

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/examples/avl/BUILD.bazel
+++ b/examples/avl/BUILD.bazel
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/examples/avl/avl.BUILD.bazel
+++ b/examples/avl/avl.BUILD.bazel
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/examples/hello_world_c/BUILD.bazel
+++ b/examples/hello_world_c/BUILD.bazel
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/examples/hello_world_c/main.c
+++ b/examples/hello_world_c/main.c
@@ -1,6 +1,8 @@
 // Copyright (c) Joby Aviation 2022
 // Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 //
+// Copyright (c) Thulio Ferraz Assis 2024
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/examples/hello_world_cpp/BUILD.bazel
+++ b/examples/hello_world_cpp/BUILD.bazel
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/examples/hello_world_cpp/main.cpp
+++ b/examples/hello_world_cpp/main.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Joby Aviation 2022
 // Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 //
+// Copyright (c) Thulio Ferraz Assis 2024
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/examples/hello_world_fortran/BUILD.bazel
+++ b/examples/hello_world_fortran/BUILD.bazel
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/examples/hello_world_fortran/main.f90
+++ b/examples/hello_world_fortran/main.f90
@@ -1,6 +1,8 @@
 ! Copyright (c) Joby Aviation 2022
 ! Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 !
+! Copyright (c) Thulio Ferraz Assis 2024
+!
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
 ! You may obtain a copy of the License at

--- a/examples/lapack/BUILD.bazel
+++ b/examples/lapack/BUILD.bazel
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/examples/lapack/patches.bzl
+++ b/examples/lapack/patches.bzl
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/examples/openssl/BUILD.bazel
+++ b/examples/openssl/BUILD.bazel
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/examples/protobuf/BUILD.bazel
+++ b/examples/protobuf/BUILD.bazel
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/examples/protobuf/hello_world.proto
+++ b/examples/protobuf/hello_world.proto
@@ -1,6 +1,8 @@
 // Copyright (c) Joby Aviation 2022
 // Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 //
+// Copyright (c) Thulio Ferraz Assis 2024
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/examples/tabulate_fortran/BUILD.bazel
+++ b/examples/tabulate_fortran/BUILD.bazel
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/examples/tabulate_fortran/functions.f90
+++ b/examples/tabulate_fortran/functions.f90
@@ -1,6 +1,8 @@
 ! Copyright (c) Joby Aviation 2022
 ! Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 !
+! Copyright (c) Thulio Ferraz Assis 2024
+!
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
 ! You may obtain a copy of the License at

--- a/examples/tabulate_fortran/tabulate.f90
+++ b/examples/tabulate_fortran/tabulate.f90
@@ -1,6 +1,8 @@
 ! Copyright (c) Joby Aviation 2022
 ! Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 !
+! Copyright (c) Thulio Ferraz Assis 2024
+!
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
 ! You may obtain a copy of the License at

--- a/internal.bzl
+++ b/internal.bzl
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/platforms/config/BUILD.bazel
+++ b/platforms/config/BUILD.bazel
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/rules_fortran/BUILD.bazel
+++ b/rules_fortran/BUILD.bazel
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/rules_fortran/defs.bzl
+++ b/rules_fortran/defs.bzl
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/sysroot/BUILD.bazel
+++ b/sysroot/BUILD.bazel
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/sysroot/Dockerfile
+++ b/sysroot/Dockerfile
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/sysroot/build.sh
+++ b/sysroot/build.sh
@@ -3,6 +3,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/sysroot/build_kernel.sh
+++ b/sysroot/build_kernel.sh
@@ -3,6 +3,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/sysroot/configure.sh
+++ b/sysroot/configure.sh
@@ -3,6 +3,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/sysroot/create_symlinks.sh
+++ b/sysroot/create_symlinks.sh
@@ -3,6 +3,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/sysroot/flags.bzl
+++ b/sysroot/flags.bzl
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/sanitizers/BUILD.bazel
+++ b/tests/sanitizers/BUILD.bazel
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/sanitizers/asan.cc
+++ b/tests/sanitizers/asan.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Joby Aviation 2022
 // Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 //
+// Copyright (c) Thulio Ferraz Assis 2024
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/tests/sanitizers/lsan.cc
+++ b/tests/sanitizers/lsan.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Joby Aviation 2022
 // Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 //
+// Copyright (c) Thulio Ferraz Assis 2024
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/tests/sanitizers/sanitizer_test.sh
+++ b/tests/sanitizers/sanitizer_test.sh
@@ -3,6 +3,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/sanitizers/tsan.cc
+++ b/tests/sanitizers/tsan.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Joby Aviation 2022
 // Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 //
+// Copyright (c) Thulio Ferraz Assis 2024
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/tests/sanitizers/ubsan.c
+++ b/tests/sanitizers/ubsan.c
@@ -1,6 +1,8 @@
 // Copyright (c) Joby Aviation 2022
 // Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 //
+// Copyright (c) Thulio Ferraz Assis 2024
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/toolchain/fortran/BUILD.bazel
+++ b/toolchain/fortran/BUILD.bazel
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/toolchain/fortran/action_names.bzl
+++ b/toolchain/fortran/action_names.bzl
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/toolchain/fortran/defs.bzl
+++ b/toolchain/fortran/defs.bzl
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/toolchain/repositories.bzl
+++ b/toolchain/repositories.bzl
@@ -1,6 +1,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/toolchain/wrapper.sh.tpl
+++ b/toolchain/wrapper.sh.tpl
@@ -3,6 +3,8 @@
 # Copyright (c) Joby Aviation 2022
 # Original authors: Thulio Ferraz Assis (thulio@aspect.dev), Aspect.dev
 #
+# Copyright (c) Thulio Ferraz Assis 2024
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
Updates the Apache 2.0 license headers to include the 2024 copyrights after the donation of the repository from aspect-build to f0rmiga.