### PR TITLE
feat: return the CcInfo provider for the Fortran rules

### DIFF
--- a/rules_fortran/defs.bzl
+++ b/rules_fortran/defs.bzl
@@ -102,6 +102,23 @@ def _fortran_binary_impl(ctx):
         providers.append(OutputGroupInfo(
             dynamic_library = depset([output]),
         ))
+        providers.append(CcInfo(
+            linking_context = cc_common.create_linking_context(
+                linker_inputs = depset([
+                    cc_common.create_linker_input(
+                        owner = ctx.label,
+                        libraries = depset([
+                            cc_common.create_library_to_link(
+                                actions = ctx.actions,
+                                feature_configuration = feature_configuration,
+                                cc_toolchain = fortran_toolchain,
+                                dynamic_library = output,
+                            ),
+                        ]),
+                    ),
+                ]),
+            ),
+        ))
 
     return providers
 
@@ -140,6 +157,23 @@ def _fortran_library_impl(ctx):
         ),
         OutputGroupInfo(
             archive = depset([output]),
+        ),
+        CcInfo(
+            linking_context = cc_common.create_linking_context(
+                linker_inputs = depset([
+                    cc_common.create_linker_input(
+                        owner = ctx.label,
+                        libraries = depset([
+                            cc_common.create_library_to_link(
+                                actions = ctx.actions,
+                                feature_configuration = feature_configuration,
+                                cc_toolchain = fortran_toolchain,
+                                static_library = output,
+                            ),
+                        ]),
+                    ),
+                ]),
+            ),
         ),
     ]
 


### PR DESCRIPTION
This enables using Fortran targets as dependencies of C/C++ targets.