### PR TITLE
fix: sysroot build libraries with position independent code

### DIFF
--- a/sysroot/configure.sh
+++ b/sysroot/configure.sh
@@ -24,6 +24,7 @@ args=()
 if [[ "${ARCH}" == "aarch64" ]]; then
     readonly target="aarch64-linux"
     args+=(
+        --with-pic
         --build=x86_64-linux-gnu
         --target="${target}"
     )
@@ -39,6 +40,7 @@ if [[ "${ARCH}" == "aarch64" ]]; then
 elif [[ "${ARCH}" == "armv7" ]]; then
     readonly target="arm-linux-gnueabihf"
     args+=(
+        --with-pic
         --build=x86_64-linux-gnu
         --target="${target}"
         --with-arch=armv7-a
@@ -58,6 +60,7 @@ elif [[ "${ARCH}" == "armv7" ]]; then
 elif [[ "${ARCH}" == "x86_64" ]]; then
     readonly target="x86_64-linux"
     args+=(
+        --with-pic
         --build=x86_64-linux-gnu
         --host="${target}"
         --target="${target}"


### PR DESCRIPTION
This was affecting mainly the static Fortran linking, which required -fpic or -fPIC to work.