### PR TITLE
fix: use relative paths for includes and flags

### DIFF
--- a/docs/defs.md
+++ b/docs/defs.md
@@ -10,7 +10,7 @@ This module provides the definitions for registering a GCC toolchain for C and C
 <pre>
 gcc_toolchain(<a href="#gcc_toolchain-name">name</a>, <a href="#gcc_toolchain-binary_prefix">binary_prefix</a>, <a href="#gcc_toolchain-extra_cflags">extra_cflags</a>, <a href="#gcc_toolchain-extra_cxxflags">extra_cxxflags</a>, <a href="#gcc_toolchain-extra_fflags">extra_fflags</a>, <a href="#gcc_toolchain-extra_ldflags">extra_ldflags</a>,
               <a href="#gcc_toolchain-fincludes">fincludes</a>, <a href="#gcc_toolchain-gcc_toolchain_workspace_name">gcc_toolchain_workspace_name</a>, <a href="#gcc_toolchain-includes">includes</a>, <a href="#gcc_toolchain-repo_mapping">repo_mapping</a>, <a href="#gcc_toolchain-target_arch">target_arch</a>,
-              <a href="#gcc_toolchain-target_compatible_with">target_compatible_with</a>, <a href="#gcc_toolchain-target_settings">target_settings</a>, <a href="#gcc_toolchain-toolchain_files_repository_name">toolchain_files_repository_name</a>)
+              <a href="#gcc_toolchain-target_compatible_with">target_compatible_with</a>, <a href="#gcc_toolchain-target_settings">target_settings</a>, <a href="#gcc_toolchain-toolchain_files">toolchain_files</a>)
 </pre>
 
 
@@ -33,7 +33,7 @@ gcc_toolchain(<a href="#gcc_toolchain-name">name</a>, <a href="#gcc_toolchain-bi
 | <a id="gcc_toolchain-target_arch"></a>target_arch |  The target architecture this toolchain produces. E.g. x86_64.   | String | required |  |
 | <a id="gcc_toolchain-target_compatible_with"></a>target_compatible_with |  contraint_values passed to target_compatible_with of the toolchain. {target_arch} is rendered to the target_arch attribute value.   | List of strings | optional | <code>["@platforms//os:linux", "@platforms//cpu:{target_arch}"]</code> |
 | <a id="gcc_toolchain-target_settings"></a>target_settings |  config_settings passed to target_compatible_with of the toolchain. {target_arch} is rendered to the target_arch attribute value.   | List of strings | optional | <code>[]</code> |
-| <a id="gcc_toolchain-toolchain_files_repository_name"></a>toolchain_files_repository_name |  The name of the repository containing the toolchain files.   | String | required |  |
+| <a id="gcc_toolchain-toolchain_files"></a>toolchain_files |  The toolchain files archive.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 
 
 <a id="gcc_register_toolchain"></a>

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -93,8 +93,6 @@ def _impl(ctx):
     extra_cxxflags = ctx.attr.extra_cxxflags
     extra_fflags = ctx.attr.extra_fflags
     extra_ldflags = ctx.attr.extra_ldflags
-    includes = ctx.attr.includes
-    fincludes = ctx.attr.fincludes
 
     action_configs = []
 
@@ -452,36 +450,6 @@ def _impl(ctx):
         ] if len(extra_fflags) > 0 else [],
     )
 
-    includes_feature_flag_sets = []
-    if len(includes) > 0:
-        includes_feature_flag_sets.append(
-            flag_set(
-                actions = all_compile_actions + [FORTRAN_ACTION_NAMES.fortran_compile],
-                flag_groups = [
-                    flag_group(
-                        flags = ["-isystem{}".format(include) for include in includes],
-                    ),
-                ],
-            ),
-        )
-    if len(fincludes) > 0:
-        includes_feature_flag_sets.append(
-            flag_set(
-                actions = [FORTRAN_ACTION_NAMES.fortran_compile],
-                flag_groups = [
-                    flag_group(
-                        flags = ["-I{}".format(finclude) for finclude in fincludes],
-                    ),
-                ],
-            ),
-        )
-
-    includes_feature = feature(
-        name = "includes",
-        enabled = True,
-        flag_sets = includes_feature_flag_sets,
-    )
-
     extra_ldflags_feature = feature(
         name = "extra_ldflags",
         enabled = True,
@@ -541,7 +509,6 @@ def _impl(ctx):
         extra_cxxflags_feature,
         extra_fflags_feature,
         extra_ldflags_feature,
-        includes_feature,
     ]
 
     return [
@@ -576,8 +543,6 @@ cc_toolchain_config = rule(
         "extra_cxxflags": attr.string_list(mandatory = True),
         "extra_fflags": attr.string_list(mandatory = True),
         "extra_ldflags": attr.string_list(mandatory = True),
-        "includes": attr.string_list(mandatory = True),
-        "fincludes": attr.string_list(mandatory = True),
         "tool_paths": attr.string_dict(mandatory = True),
     },
     provides = [CcToolchainConfigInfo],


### PR DESCRIPTION
This fix allows RBE to work and have shared cache between systems as no absolute path cripples in, making all paths in flags deterministic.

A negative side-effect of this fix is that toolchains for all platforms that are registered will first extract the toolchain files, even for platforms that are not requested during build.

This negative impact is partially mitigated by PR #186 that significantly reduces the toolchain archive sizes to about 25% of the original size.