### PR TITLE
feat: Add extra_asmflags to pass custom flags to `ACTION_NAME.preprocessor_assemble`

### DIFF
--- a/docs/defs.md
+++ b/docs/defs.md
@@ -8,9 +8,9 @@ This module provides the definitions for registering a GCC toolchain for C and C
 ## gcc_toolchain
 
 <pre>
-gcc_toolchain(<a href="#gcc_toolchain-name">name</a>, <a href="#gcc_toolchain-binary_prefix">binary_prefix</a>, <a href="#gcc_toolchain-extra_cflags">extra_cflags</a>, <a href="#gcc_toolchain-extra_cxxflags">extra_cxxflags</a>, <a href="#gcc_toolchain-extra_fflags">extra_fflags</a>, <a href="#gcc_toolchain-extra_ldflags">extra_ldflags</a>,
-              <a href="#gcc_toolchain-fincludes">fincludes</a>, <a href="#gcc_toolchain-gcc_toolchain_workspace_name">gcc_toolchain_workspace_name</a>, <a href="#gcc_toolchain-gcc_version">gcc_version</a>, <a href="#gcc_toolchain-gcc_versions">gcc_versions</a>, <a href="#gcc_toolchain-includes">includes</a>,
-              <a href="#gcc_toolchain-repo_mapping">repo_mapping</a>, <a href="#gcc_toolchain-target_arch">target_arch</a>, <a href="#gcc_toolchain-target_compatible_with">target_compatible_with</a>, <a href="#gcc_toolchain-target_settings">target_settings</a>)
+gcc_toolchain(<a href="#gcc_toolchain-name">name</a>, <a href="#gcc_toolchain-binary_prefix">binary_prefix</a>, <a href="#gcc_toolchain-extra_asmflags">extra_asmflags</a>, <a href="#gcc_toolchain-extra_cflags">extra_cflags</a>, <a href="#gcc_toolchain-extra_cxxflags">extra_cxxflags</a>, <a href="#gcc_toolchain-extra_fflags">extra_fflags</a>,
+              <a href="#gcc_toolchain-extra_ldflags">extra_ldflags</a>, <a href="#gcc_toolchain-fincludes">fincludes</a>, <a href="#gcc_toolchain-gcc_toolchain_workspace_name">gcc_toolchain_workspace_name</a>, <a href="#gcc_toolchain-gcc_version">gcc_version</a>, <a href="#gcc_toolchain-gcc_versions">gcc_versions</a>,
+              <a href="#gcc_toolchain-includes">includes</a>, <a href="#gcc_toolchain-repo_mapping">repo_mapping</a>, <a href="#gcc_toolchain-target_arch">target_arch</a>, <a href="#gcc_toolchain-target_compatible_with">target_compatible_with</a>, <a href="#gcc_toolchain-target_settings">target_settings</a>)
 </pre>
 
 
@@ -22,6 +22,7 @@ gcc_toolchain(<a href="#gcc_toolchain-name">name</a>, <a href="#gcc_toolchain-bi
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="gcc_toolchain-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="gcc_toolchain-binary_prefix"></a>binary_prefix |  An explicit prefix used by each binary in bin/.   | String | required |  |
+| <a id="gcc_toolchain-extra_asmflags"></a>extra_asmflags |  Extra flags for the assembly preprocessor.   | List of strings | optional | <code>[]</code> |
 | <a id="gcc_toolchain-extra_cflags"></a>extra_cflags |  Extra flags for compiling C.   | List of strings | optional | <code>[]</code> |
 | <a id="gcc_toolchain-extra_cxxflags"></a>extra_cxxflags |  Extra flags for compiling C++.   | List of strings | optional | <code>[]</code> |
 | <a id="gcc_toolchain-extra_fflags"></a>extra_fflags |  Extra flags for compiling Fortran.   | List of strings | optional | <code>[]</code> |

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -18,6 +18,7 @@
 """This module provides the cc_toolchain_config rule.
 """
 
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load(
     "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
     "action_config",
@@ -28,7 +29,6 @@ load(
     "tool_path",
     "with_feature_set",
 )
-load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("//toolchain/fortran:action_names.bzl", FORTRAN_ACTION_NAMES = "ACTION_NAMES")
 
 all_compile_actions = [
@@ -93,6 +93,7 @@ def _impl(ctx):
     extra_cxxflags = ctx.attr.extra_cxxflags
     extra_fflags = ctx.attr.extra_fflags
     extra_ldflags = ctx.attr.extra_ldflags
+    extra_asmflags = ctx.attr.extra_asmflags
 
     action_configs = []
 
@@ -461,6 +462,17 @@ def _impl(ctx):
         ] if len(extra_ldflags) > 0 else [],
     )
 
+    extra_asmflags_feature = feature(
+        name = "extra_asmflags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [ACTION_NAMES.preprocess_assemble],
+                flag_groups = [flag_group(flags = extra_asmflags)],
+            ),
+        ] if len(extra_asmflags) > 0 else [],
+    )
+
     sysroot_feature = feature(
         name = "sysroot",
         enabled = True,
@@ -509,6 +521,7 @@ def _impl(ctx):
         extra_cxxflags_feature,
         extra_fflags_feature,
         extra_ldflags_feature,
+        extra_asmflags_feature,
     ]
 
     return [
@@ -543,6 +556,7 @@ cc_toolchain_config = rule(
         "extra_cxxflags": attr.string_list(mandatory = True),
         "extra_fflags": attr.string_list(mandatory = True),
         "extra_ldflags": attr.string_list(mandatory = True),
+        "extra_asmflags": attr.string_list(mandatory = True),
         "tool_paths": attr.string_dict(mandatory = True),
     },
     provides = [CcToolchainConfigInfo],

--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -205,6 +205,17 @@ def _gcc_toolchain_impl(rctx):
     ]
     extra_ldflags.extend(rctx.attr.extra_ldflags)
 
+    extra_asmflags = []
+    extra_asmflags.extend([
+        "-isystem{}".format(include)
+        for include in c_builtin_includes
+    ])
+    extra_asmflags.extend([
+        "-I{}".format(include)
+        for include in rctx.attr.includes
+    ])
+    extra_asmflags.extend(rctx.attr.extra_asmflags)
+
     rctx.file("BUILD.bazel", _TOOLCHAIN_BUILD_FILE_CONTENT.format(
         gcc_toolchain_workspace_name = rctx.attr.gcc_toolchain_workspace_name,
         target_compatible_with = target_compatible_with,
@@ -220,6 +231,7 @@ def _gcc_toolchain_impl(rctx):
         extra_cxxflags = _format_flags(extra_cxxflags),
         extra_fflags = _format_flags(extra_fflags),
         extra_ldflags = _format_flags(extra_ldflags),
+        extra_asmflags = _format_flags(extra_asmflags),
     ))
 
 AVAILABLE_GCC_VERSIONS = {
@@ -306,6 +318,10 @@ _FEATURE_ATTRS = {
               " See https://github.com/bazelbuild/bazel/blob/a48e246e/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainProviderHelper.java#L234-L254.",
         default = [],
     ),
+    "extra_asmflags": attr.string_list(
+        doc = "Extra flags for the assembly preprocessor.",
+        default = [],
+    ),
     "gcc_toolchain_workspace_name": attr.string(
         doc = "The name given to the gcc-toolchain repository, if the default was not used.",
         default = "gcc_toolchain",
@@ -365,7 +381,7 @@ gcc_toolchain = repository_rule(
 
 ATTRS_SHARED_WITH_MODULE_EXTENSION = {
     attr_name: _FEATURE_ATTRS[attr_name]
-    for attr_name in ["gcc_version", "gcc_versions", "extra_cflags", "extra_cxxflags", "extra_ldflags", "extra_fflags"]
+    for attr_name in ["gcc_version", "gcc_versions", "extra_cflags", "extra_cxxflags", "extra_ldflags", "extra_fflags", "extra_asmflags"]
 }
 
 def _render_tool_paths(rctx, path_prefix, binary_prefix):
@@ -479,6 +495,7 @@ def gcc_declare_toolchain(
         extra_cxxflags = kwargs.pop("extra_cxxflags", []),
         extra_fflags = kwargs.pop("extra_fflags", []),
         extra_ldflags = kwargs.pop("extra_ldflags", []),
+        extra_asmflags = kwargs.pop("extra_asmflags", []),
         includes = kwargs.pop("includes", []),
         fincludes = kwargs.pop("fincludes", []),
         target_arch = target_arch,
@@ -565,6 +582,7 @@ cc_toolchain_config(
     extra_cxxflags = {extra_cxxflags},
     extra_fflags = {extra_fflags},
     extra_ldflags = {extra_ldflags},
+    extra_asmflags = {extra_asmflags},
     tool_paths = tool_paths,
 )
 


### PR DESCRIPTION


If found a problem: Some assembly files depend on builtin imports (e.g. the ones in boringssl). Currently, the way we make those imports available to targets is by adding all the `-isystem` et.al. flags into `extra_xxxx` attributes and passing them down to the cc_toolchain_config. However, the cc_toolchain_config doesn't apply those flags to `ACTION_NAME.preprocessor_assemble`.

This PR adds an `extra_asmflags` attribute to `gcc_toolchain` (and all the way down the chain). This solves the issue because we populate that attribute with the same imports we use for C code, but it also allows consumers to specify flags for the assembler.

An alternative could be to apply `extra_cflags` to `ACTION_NAME.preprocessor_assemble`. This is also a good alternative, I don't have a strong opinion on the matter. @f0rmiga what do you think?