### PR TITLE
feat: implement the external_include_paths feature

### DIFF
--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -413,6 +413,36 @@ def _impl(ctx):
         ],
     )
 
+    # Opt-in: routes headers from external repositories through -isystem so
+    # their diagnostics do not fail a -Werror build of first-party code.
+    # Mirrors rules_cc's unix_cc_toolchain_config:
+    # https://github.com/bazelbuild/rules_cc/blob/0.2.22/cc/private/toolchain/unix_cc_toolchain_config.bzl
+    external_include_paths_feature = feature(
+        name = "external_include_paths",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.clif_match,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-isystem", "%{external_include_paths}"],
+                        iterate_over = "external_include_paths",
+                        expand_if_available = "external_include_paths",
+                    ),
+                ],
+            ),
+        ],
+    )
+
     library_search_directories_feature = feature(
         name = "library_search_directories",
         flag_sets = [
@@ -555,6 +585,7 @@ def _impl(ctx):
         [
             default_compile_flags_feature,
             include_paths_feature,
+            external_include_paths_feature,
             library_search_directories_feature,
             default_link_flags_feature,
             linker_lld_feature,


### PR DESCRIPTION
Fixes #215.

`external_include_paths` is not a Bazel built-in; each `cc_toolchain_config` has to implement it. rules_cc implements it in [`unix_cc_toolchain_config.bzl`][rules-cc], and toolchains_llvm [delegates to that config][llvm], which is why the LLVM toolchain honours `--features=external_include_paths`.

This toolchain has [its own `cc_toolchain_config.bzl`][gcct] and never defined the feature, so the flag is silently a no-op — Bazel does not warn when you request a feature a toolchain lacks. External headers arrive as `-I` / `-iquote` instead of `-isystem`, which breaks `#include <...>` lookups (the symptom in #215) and, in repos that build first-party code with `-Werror`, any warning inside a vendored header turns into an error.

The feature added here mirrors rules_cc's, restricted to the action names this toolchain already uses in [`include_paths_feature`][gcct]. The flag group carries
`expand_if_available = "external_include_paths"`, so it stays inert unless the feature is requested and the variable is set — no existing behaviour changes when it is off.

### Verification

On a repo that builds C++ with `-Werror` against a vendored googletest, same target and same flag, before and after:

```
# before
-Iexternal/googletest+/googletest/include

# after — matches what toolchains_llvm already produced
-isystem external/googletest+/googletest/include
```

Before the change that target failed to compile on `-Werror=sign-compare` raised inside `gtest.h`; after it, it builds. The LLVM build is unaffected either way, since it never depended on this toolchain's config.

[rules-cc]: https://github.com/bazelbuild/rules_cc/blob/0.2.22/cc/private/toolchain/unix_cc_toolchain_config.bzl#L1144
[llvm]: https://github.com/bazel-contrib/toolchains_llvm/blob/v1.8.0/toolchain/cc_toolchain_config.bzl#L19
[gcct]: https://github.com/f0rmiga/gcc-toolchain/blob/0.12.1/toolchain/cc_toolchain_config.bzl#L382
